### PR TITLE
Handle sciety-like docmaps that are generated by the canonical ETL tool

### DIFF
--- a/src/docmaps.js
+++ b/src/docmaps.js
@@ -41,7 +41,7 @@ function getDate(dateString) {
 }
 
 function getText(output) {
-  const textContent = output.content.find(c => c.type === 'text');
+  const textContent = output.content?.find(c => c.type === 'text');
   if (!textContent) {
     return null;
   }
@@ -56,11 +56,18 @@ const TimelineItemTypes = {
   ReviewArticle: 'review-article',
 };
 const DocmapOutputTypes = {
-  JournalPublication: 'journal-publication',
-  Response: 'author-response',
   Review: 'review',
   ReviewArticle: 'review-article',
   ReviewsSummary: 'reviews-summary',
+
+  // TODO: adopt these Canonical output types,
+  // * see https://github.com/Docmaps-Project/docmaps/pull/58
+  JournalArticle: 'journal-article',
+  Reply: 'reply', // instead of author-response
+
+  // TODO: deprecate these Non canonical output types.
+  JournalPublication: 'journal-publication',
+  Response: 'author-response',
 };
 
 function isSingleActionStep(step) {
@@ -134,8 +141,13 @@ async function parseStep(step) {
           src: getText(output),
         };
       })
+      // pessimistic sort - sort by date if no running numbers available
+      .sort((a, b) => a.date.valueOf() - b.date.valueOf())
+      // optimistic sort - does nothing if no running number available
       .sort((a, b) => a.runningNumber - b.runningNumber);
-    const earliestDate = contents.map(c => c.date).sort()[0];
+    const earliestDate = contents
+      .map(c => c.date)
+      .sort((a, b) => a.valueOf() - b.valueOf())[0];
     const item = {
       contents,
       date: earliestDate,
@@ -168,10 +180,11 @@ async function parseStep(step) {
 
   const isJournalPublicationStep =
     isSingleActionStep(step) &&
-    hasSingleOutputOfType(
+    (hasSingleOutputOfType(
       step.actions[0],
       DocmapOutputTypes.JournalPublication
-    );
+    ) ||
+      hasSingleOutputOfType(step.actions[0], DocmapOutputTypes.JournalArticle));
   if (isJournalPublicationStep) {
     const output = step.actions[0].outputs[0];
     const item = {
@@ -207,6 +220,10 @@ function getPublisher(input) {
   );
 }
 
+function uriForDoi(doi) {
+  return `https://doi.org/${doi}`;
+}
+
 function getFirstGroup(inputs) {
   const input = inputs[0];
   return {
@@ -215,7 +232,7 @@ function getFirstGroup(inputs) {
       {
         date: getDate(input.published),
         type: TimelineItemTypes.Preprint,
-        uri: input.uri || input.url,
+        uri: input.uri || input.url || uriForDoi(input.doi),
       },
     ],
   };
@@ -226,7 +243,15 @@ async function parseDocmapIntoGroups(timeline, docmap) {
   const steps = Array.from(stepsGenerator(docmap['first-step'], docmap.steps));
   if (timeline.groups.length === 0) {
     log('adding first group to empty timeline');
-    timeline.groups.push(getFirstGroup(steps[0].inputs));
+    // Check if first step has any inputs
+    const firstStepHasInputs = steps[0].inputs && steps[0].inputs.length > 0;
+
+    // If first step has no inputs, use Outputs section instead
+    if (!firstStepHasInputs) {
+      timeline.groups.push(getFirstGroup(steps[0].actions[0].outputs));
+    } else {
+      timeline.groups.push(getFirstGroup(steps[0].inputs));
+    }
   }
 
   const publisherUri =

--- a/src/docmaps.js
+++ b/src/docmaps.js
@@ -96,6 +96,14 @@ function isReviewsSummaryAction(action) {
   return hasSingleOutputOfType(action, DocmapOutputTypes.ReviewsSummary);
 }
 
+function uriForDoi(doi) {
+  return `https://doi.org/${doi}`;
+}
+
+function uriForThing(io) {
+  return io.uri || io.url || uriForDoi(io.doi);
+}
+
 async function parseStep(step) {
   log('parsing step', step);
 
@@ -191,7 +199,7 @@ async function parseStep(step) {
       date: getDate(output.published),
       doi: output.doi,
       type: TimelineItemTypes.JournalPublication,
-      uri: output.uri,
+      uri: uriForThing(output),
     };
     log('added journal publication item', item);
     return [item];
@@ -220,10 +228,6 @@ function getPublisher(input) {
   );
 }
 
-function uriForDoi(doi) {
-  return `https://doi.org/${doi}`;
-}
-
 function getFirstGroup(inputs) {
   const input = inputs[0];
   return {
@@ -232,7 +236,7 @@ function getFirstGroup(inputs) {
       {
         date: getDate(input.published),
         type: TimelineItemTypes.Preprint,
-        uri: input.uri || input.url || uriForDoi(input.doi),
+        uri: uriForThing(input),
       },
     ],
   };

--- a/src/render-rev-timeline.js
+++ b/src/render-rev-timeline.js
@@ -6,7 +6,7 @@ import { GlobalStyles } from './styles.js';
 import '@spider-ui/tooltip';
 
 function toClassName(str) {
-  return str.replaceAll(/[^a-zA-Z0-9-_]/g, '');
+  return str?.replaceAll(/[^a-zA-Z0-9-_]/g, '') || 'undefined';
 }
 
 function itemDescription(item) {

--- a/test/resources/sample-docmaps.js
+++ b/test/resources/sample-docmaps.js
@@ -1,6 +1,5 @@
 export const docmapsByDoi = {
   '10.5194/angeo-40-247-2022': [
-    // NOTE: normal cases do not inclde the docmap: key
     {
       type: 'docmap',
       id: 'https://docmaps-project.github.io/ex/docmap_for/10.5194/angeo-40-247-2022',
@@ -1242,7 +1241,7 @@ export const reviewProcessByDoi = {
               date: new Date('2022-05-02T00:00:00.000Z'),
               doi: '10.5194/angeo-40-247-2022',
               type: 'journal-publication',
-              uri: undefined,
+              uri: 'https://doi.org/10.5194/angeo-40-247-2022',
             },
             {
               contents: [

--- a/test/resources/sample-docmaps.js
+++ b/test/resources/sample-docmaps.js
@@ -1,4 +1,248 @@
 export const docmapsByDoi = {
+  '10.5194/angeo-40-247-2022': [
+    // NOTE: normal cases do not inclde the docmap: key
+    {
+      type: 'docmap',
+      id: 'https://docmaps-project.github.io/ex/docmap_for/10.5194/angeo-40-247-2022',
+      publisher: {
+        name: 'Docmaps Project',
+        url: 'https://docmaps-project.github.io',
+      },
+      created: '2023-05-31T22:43:16.441Z',
+      updated: '2023-05-31T22:43:16.441Z',
+      'first-step': '_:b0',
+      steps: {
+        '_:b0': {
+          inputs: [],
+          actions: [
+            {
+              participants: [
+                {
+                  actor: { type: 'person', name: 'Hwang, Jun-Young' },
+                  role: 'author',
+                },
+                {
+                  actor: { type: 'person', name: 'Lee, Young-Sook' },
+                  role: 'author',
+                },
+                {
+                  actor: { type: 'person', name: 'Kim, Yong Ha' },
+                  role: 'author',
+                },
+                {
+                  actor: { type: 'person', name: 'Kam, Hosik' },
+                  role: 'author',
+                },
+                {
+                  actor: { type: 'person', name: 'Kwak, Young-Sil' },
+                  role: 'author',
+                },
+                {
+                  actor: { type: 'person', name: 'Yang, Tae-Yong' },
+                  role: 'author',
+                },
+              ],
+              outputs: [
+                {
+                  published: '2021-11-10T00:00:00.000Z',
+                  doi: '10.5194/angeo-2021-65',
+                  type: 'preprint',
+                },
+              ],
+            },
+          ],
+          assertions: [{ status: 'catalogued', item: '10.5194/angeo-2021-65' }],
+          'next-step': '_:b1',
+        },
+        '_:b1': {
+          actions: [
+            {
+              participants: [],
+              outputs: [
+                {
+                  published: '2021-11-16T00:00:00.000Z',
+                  doi: '10.5194/angeo-2021-65-rc1',
+                  type: 'review',
+                },
+              ],
+            },
+            {
+              participants: [],
+              outputs: [
+                {
+                  published: '2021-11-24T00:00:00.000Z',
+                  doi: '10.5194/angeo-2021-65-rc2',
+                  type: 'review',
+                },
+              ],
+            },
+          ],
+          inputs: [
+            {
+              published: '2021-11-10T00:00:00.000Z',
+              doi: '10.5194/angeo-2021-65',
+              type: 'preprint',
+            },
+          ],
+          assertions: [{ status: 'reviewed', item: '10.5194/angeo-2021-65' }],
+          'previous-step': '_:b0',
+          'next-step': '_:b2',
+        },
+        '_:b2': {
+          inputs: [
+            {
+              published: '2021-11-10T00:00:00.000Z',
+              doi: '10.5194/angeo-2021-65',
+              type: 'preprint',
+            },
+          ],
+          actions: [
+            {
+              participants: [
+                {
+                  actor: { type: 'person', name: 'Hwang, Jun-Young' },
+                  role: 'author',
+                },
+                {
+                  actor: { type: 'person', name: 'Lee, Young-Sook' },
+                  role: 'author',
+                },
+                {
+                  actor: { type: 'person', name: 'Kim, Yong Ha' },
+                  role: 'author',
+                },
+                {
+                  actor: { type: 'person', name: 'Kam, Hosik' },
+                  role: 'author',
+                },
+                {
+                  actor: { type: 'person', name: 'Song, Seok-Min' },
+                  role: 'author',
+                },
+                {
+                  actor: { type: 'person', name: 'Kwak, Young-Sil' },
+                  role: 'author',
+                },
+                {
+                  actor: { type: 'person', name: 'Yang, Tae-Yong' },
+                  role: 'author',
+                },
+              ],
+              outputs: [
+                {
+                  published: '2022-05-02T00:00:00.000Z',
+                  doi: '10.5194/angeo-40-247-2022',
+                  type: 'journal-article',
+                },
+              ],
+            },
+          ],
+          assertions: [
+            {
+              status: 'published',
+              item: '10.5194/angeo-40-247-2022',
+            },
+          ],
+          'previous-step': '_:b1',
+          'next-step': '_:b3',
+        },
+        '_:b3': {
+          actions: [
+            {
+              participants: [],
+              outputs: [
+                {
+                  published: '2021-11-16T00:00:00.000Z',
+                  doi: '10.5194/angeo-2021-65-rc1',
+                  type: 'review',
+                },
+              ],
+            },
+            {
+              participants: [],
+              outputs: [
+                {
+                  published: '2021-11-27T00:00:00.000Z',
+                  doi: '10.5194/angeo-2021-65-cc1',
+                  type: 'review',
+                },
+              ],
+            },
+            {
+              participants: [
+                {
+                  actor: { type: 'person', name: 'Lee, Young-Sook' },
+                  role: 'author',
+                },
+              ],
+              outputs: [
+                {
+                  published: '2022-01-03T00:00:00.000Z',
+                  doi: '10.5194/angeo-2021-65-ac2',
+                  type: 'review',
+                },
+              ],
+            },
+            {
+              participants: [],
+              outputs: [
+                {
+                  published: '2021-11-24T00:00:00.000Z',
+                  doi: '10.5194/angeo-2021-65-rc2',
+                  type: 'review',
+                },
+              ],
+            },
+            {
+              participants: [
+                {
+                  actor: { type: 'person', name: 'Lee, Young-Sook' },
+                  role: 'author',
+                },
+              ],
+              outputs: [
+                {
+                  published: '2021-12-23T00:00:00.000Z',
+                  doi: '10.5194/angeo-2021-65-ac1',
+                  type: 'review',
+                },
+              ],
+            },
+            {
+              participants: [
+                {
+                  actor: { type: 'person', name: 'Lee, Young-Sook' },
+                  role: 'author',
+                },
+              ],
+              outputs: [
+                {
+                  published: '2022-01-27T00:00:00.000Z',
+                  doi: '10.5194/angeo-2021-65-ac3',
+                  type: 'review',
+                },
+              ],
+            },
+          ],
+          inputs: [
+            {
+              published: '2022-05-02T00:00:00.000Z',
+              doi: '10.5194/angeo-40-247-2022',
+              type: 'journal-article',
+            },
+          ],
+          assertions: [
+            {
+              status: 'reviewed',
+              item: '10.5194/angeo-40-247-2022',
+            },
+          ],
+          'previous-step': '_:b2',
+        },
+      },
+      '@context': 'https://w3id.org/docmaps/context.jsonld',
+    },
+  ],
   '10.1101/2020.07.20.212886': [
     {
       docmap: {
@@ -944,6 +1188,104 @@ export const reviewProcessByDoi = {
               doi: '10.1371/journal.pone.0217516',
               type: 'journal-publication',
               uri: 'https://doi.org/10.1371/journal.pone.0217516',
+            },
+          ],
+        },
+      ],
+    },
+  },
+  '10.5194/angeo-40-247-2022': {
+    timeline: {
+      groups: [
+        {
+          publisher: {
+            name: null,
+            uri: null,
+          },
+          items: [
+            {
+              date: new Date('2021-11-10T00:00:00.000Z'),
+              type: 'preprint-posted', // TODO validate this, based on output type
+              uri: 'https://doi.org/10.5194/angeo-2021-65',
+              // TODO: this could be included
+              // doi: '10.5194/angeo-40-247-2022'
+            },
+          ],
+        },
+        {
+          publisher: {
+            name: 'Docmaps Project',
+            uri: 'https://docmaps-project.github.io',
+            peerReviewPolicy: undefined,
+          },
+          items: [
+            {
+              contents: [
+                {
+                  doi: '10.5194/angeo-2021-65-rc1',
+                  date: new Date('2021-11-16T00:00:00.000Z'),
+                  runningNumber: undefined,
+                  src: null,
+                },
+                {
+                  date: new Date('2021-11-24T00:00:00.000Z'),
+                  doi: '10.5194/angeo-2021-65-rc2',
+                  runningNumber: undefined,
+                  src: null,
+                },
+              ],
+              summaries: [],
+              date: new Date('2021-11-16T00:00:00.000Z'),
+              type: 'reviews',
+            },
+            {
+              date: new Date('2022-05-02T00:00:00.000Z'),
+              doi: '10.5194/angeo-40-247-2022',
+              type: 'journal-publication',
+              uri: undefined,
+            },
+            {
+              contents: [
+                {
+                  doi: '10.5194/angeo-2021-65-rc1',
+                  date: new Date('2021-11-16T00:00:00.000Z'),
+                  runningNumber: undefined,
+                  src: null,
+                },
+                {
+                  doi: '10.5194/angeo-2021-65-rc2',
+                  date: new Date('2021-11-24T00:00:00.000Z'),
+                  runningNumber: undefined,
+                  src: null,
+                },
+                {
+                  doi: '10.5194/angeo-2021-65-cc1',
+                  date: new Date('2021-11-27T00:00:00.000Z'),
+                  runningNumber: undefined,
+                  src: null,
+                },
+                {
+                  doi: '10.5194/angeo-2021-65-ac1',
+                  date: new Date('2021-12-23T00:00:00.000Z'),
+                  runningNumber: undefined,
+                  src: null,
+                },
+                {
+                  doi: '10.5194/angeo-2021-65-ac2',
+                  date: new Date('2022-01-03T00:00:00.000Z'),
+                  runningNumber: undefined,
+                  src: null,
+                },
+                {
+                  doi: '10.5194/angeo-2021-65-ac3',
+                  date: new Date('2022-01-27T00:00:00.000Z'),
+                  runningNumber: undefined,
+                  src: null,
+                },
+              ],
+              summaries: [],
+              date: new Date('2021-11-16T00:00:00.000Z'),
+              type: 'reviews',
             },
           ],
         },


### PR DESCRIPTION
Currently, render-rev's handling of Sciety-style docmaps will error rather than emit a (limited) visual rendering in certain cases:

- if the first step in the docmap has no inputs. This is common in our use case where we instead have a Step for the production of the preprint itself  rather than it being the first input to the first step.
- if no publisher is provided in the docmap. This is just a display issue but it's healthy to have the widget still display and show where data is missing rather than an error in the system.
- if no `output.content`. Now, show `src: null` (matching case where `output.content` has no `text` entry) rather than failing to display at all.
- When using `journal-article` rather than `journal-publication` as the output `type`. This is canonical, and the PR doesn't break existing behavior, but leaves a comment to deprecate/change that in future.
- if a preprint has a DOI but no URL. now, construct the doi.org url for that preprint.

Additionally, there is a small fix to date sorting logic.

I have added one test case matching this structure (using an actual example I generated using our tool).
